### PR TITLE
Port forward

### DIFF
--- a/cmd/port_forward.go
+++ b/cmd/port_forward.go
@@ -1,0 +1,155 @@
+// mystack-controller api
+// https://github.com/topfreegames/mystack-controller
+//
+// Licensed under the MIT license:
+// http://www.opensource.org/licenses/mit-license
+// Copyright © 2017 Top Free Games <backend@tfgco.com>
+
+package cmd
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/topfreegames/mystack-cli/models"
+)
+
+var tcpPort int
+var interactive bool
+
+var startPort int = 28000
+var wg sync.WaitGroup
+
+func getServiceNames(l *logrus.Entry, clusterName string) ([]string, error) {
+	l.Debug("ready to get cluster services")
+	url := fmt.Sprintf("%s/clusters/%s/services", config.ControllerURL, clusterName)
+	client := models.NewMyStackHTTPClient(config)
+	body, status, err := client.Get(url, config.ControllerHost)
+	if err != nil {
+		return nil, err
+	}
+
+	if status == http.StatusNotFound {
+		return nil, fmt.Errorf("cluster '%s' was not found\nyou have to run './mystack create cluster %s'", clusterName, clusterName)
+	} else if status != http.StatusOK {
+		return nil, fmt.Errorf("Status: %d\nBody: %s", status, body)
+	}
+
+	bodyJSON := make(map[string][]string)
+	err = json.Unmarshal(body, &bodyJSON)
+	if err != nil {
+		log.Fatal(err.Error())
+		return nil, err
+	}
+
+	return bodyJSON["services"], nil
+}
+
+func readPort(service string, shiftPort int) (int, int) {
+	tcpPort = startPort + shiftPort
+	for {
+		reader := bufio.NewReader(os.Stdin)
+		fmt.Printf("Choose port to bind for %s [Default %d]: ", service, tcpPort)
+		portStr, _ := reader.ReadString('\n')
+		portStr = strings.TrimSpace(portStr)
+
+		if portStr == "" {
+			shiftPort = shiftPort + 1
+			break
+		}
+
+		port64, err := strconv.ParseUint(portStr, 10, 64)
+		if err != nil {
+			fmt.Println("Error: choose a valid port number")
+			continue
+		}
+
+		tcpPort = int(port64)
+		break
+	}
+
+	return tcpPort, shiftPort
+}
+
+func bindPorts(services []string, l logrus.FieldLogger) {
+	shiftPort := 0
+	printer := models.NewPortForwarderPrinter()
+	for _, service := range services {
+		tcpPort := startPort + shiftPort
+		if interactive {
+			tcpPort, shiftPort = readPort(service, shiftPort)
+		} else {
+			shiftPort = shiftPort + 1
+		}
+
+		localAddr := fmt.Sprintf(":%d", tcpPort)
+		remoteAddr := fmt.Sprintf("%s:28000", strings.Split(config.ControllerURL, "://")[1])
+
+		message := map[string]interface{}{
+			"token":   config.Token,
+			"service": service,
+		}
+
+		proxy := models.NewProxy(localAddr, remoteAddr, message)
+
+		printer.Add(service, localAddr)
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := proxy.Start()
+			if err != nil {
+				l.WithError(err).Fatal("error while port forwarding")
+			}
+		}()
+	}
+
+	printer.Print()
+}
+
+// portForwardCmd represents the portForward command
+var portForwardCmd = &cobra.Command{
+	Use:   "port-forward",
+	Short: "Forward service ports",
+	Long:  `Binds local ports to access mystack services on kubernetes cluster`,
+	Run: func(cmd *cobra.Command, args []string) {
+		log := createLog()
+
+		c, err := models.ReadConfig(environment)
+		if err == nil {
+			config = c
+		} else {
+			log.WithError(err).Fatal("no mystack config file found, you may need to run './mystack login'")
+		}
+
+		l := log.WithFields(logrus.Fields{
+			"controllerURL": config.ControllerURL,
+		})
+
+		if len(args) == 0 {
+			fmt.Println("cluster name must be informed, e.g './mystack port-forward mycluster'")
+			return
+		}
+
+		services, err := getServiceNames(l, args[0])
+		if err != nil {
+			l.WithError(err).Fatal("error while port forwarding")
+		}
+
+		bindPorts(services, l)
+		wg.Wait()
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(portForwardCmd)
+	portForwardCmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "Interative mode to choose ports to bind")
+}

--- a/models/port_forward_printer.go
+++ b/models/port_forward_printer.go
@@ -1,0 +1,55 @@
+// mystack-cli api
+// https://github.com/topfreegames/mystack-cli
+//
+// Licensed under the MIT license:
+// http://www.opensource.org/licenses/mit-license
+// Copyright © 2017 Top Free Games <backend@tfgco.com>
+
+package models
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"text/tabwriter"
+)
+
+//PortForwardPrinter implements the Printer interface
+//It prints the port binded for each mystack service of a cluster
+type PortForwardPrinter struct {
+	svcs map[string]string
+}
+
+//NewPortForwarderPrinter returns a PortForwardPrinter
+func NewPortForwarderPrinter() *PortForwardPrinter {
+	return &PortForwardPrinter{
+		svcs: make(map[string]string),
+	}
+}
+
+//Add a new port binded to a service
+func (p *PortForwardPrinter) Add(service, host string) {
+	p.svcs[service] = host
+}
+
+//Print formats and prints the ports for each service
+func (p *PortForwardPrinter) Print() {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+
+	services := make([]string, len(p.svcs))
+	i := 0
+	for name, _ := range p.svcs {
+		services[i] = name
+		i = i + 1
+	}
+
+	sort.Strings(services)
+
+	fmt.Println("Port forward is running")
+	fmt.Fprintf(w, "%s \t%v\n", "SERVICE", "LOCAL HOSTNAME")
+	for _, name := range services {
+		fmt.Fprintf(w, "%s \t%v\n", name, p.svcs[name])
+	}
+
+	w.Flush()
+}

--- a/models/proxy.go
+++ b/models/proxy.go
@@ -1,0 +1,126 @@
+// mystack-controller api
+// https://github.com/topfreegames/mystack-controller
+//
+// Licensed under the MIT license:
+// http://www.opensource.org/licenses/mit-license
+// Copyright © 2017 Top Free Games <backend@tfgco.com>
+
+package models
+
+import (
+	"encoding/json"
+	"io"
+	"net"
+	"sync"
+
+	"github.com/Sirupsen/logrus"
+)
+
+type Proxy struct {
+	from     string
+	to       string
+	done     chan struct{}
+	messages map[string]interface{}
+	log      *logrus.Entry
+}
+
+func NewProxy(from, to string, messages map[string]interface{}) *Proxy {
+	return &Proxy{
+		from: from,
+		to:   to,
+		done: make(chan struct{}),
+		log: logrus.WithFields(logrus.Fields{
+			"from": from,
+		}),
+		messages: messages,
+	}
+}
+
+func (p *Proxy) Start() error {
+	listener, err := net.Listen("tcp", p.from)
+	if err != nil {
+		return err
+	}
+	p.run(listener)
+	return nil
+}
+
+func (p *Proxy) Stop() {
+	p.log.Infoln("Stopping proxy")
+	if p.done == nil {
+		return
+	}
+	close(p.done)
+	p.done = nil
+}
+
+func (p *Proxy) run(listener net.Listener) {
+	for {
+		select {
+		case <-p.done:
+			return
+		default:
+			connection, err := listener.Accept()
+			if err == nil {
+				go p.handle(connection)
+			} else {
+				p.log.WithField("err", err).Errorln("Error accepting conn")
+			}
+		}
+	}
+}
+
+func (p *Proxy) handle(connection net.Conn) {
+	p.log.Debugln("Handling", connection)
+	defer p.log.Debugln("Done handling", connection)
+	defer connection.Close()
+	remote, err := net.Dial("tcp", p.to)
+	if err != nil {
+		p.log.WithField("err", err).Errorln("Error dialing remote host")
+		return
+	}
+	defer remote.Close()
+
+	p.handshake(remote)
+
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	go p.copy(remote, connection, wg)
+	go p.copy(connection, remote, wg)
+
+	wg.Wait()
+}
+
+func (p *Proxy) handshake(remote net.Conn) {
+	bts, err := json.Marshal(p.messages)
+	if err != nil {
+		p.log.Fatalf("invalid handshake message: %s\n", err.Error())
+	}
+
+	bts = append(bts, '\n')
+
+	_, err = remote.Write(bts)
+	if err != nil {
+		p.log.Fatalf("handshake error: %s\n", err.Error())
+	}
+
+	authRes := make([]byte, 1024)
+	_, err = remote.Read(authRes)
+	if err != nil {
+		p.log.Fatalf("read ack error: %s\n", err.Error())
+	}
+}
+
+func (p *Proxy) copy(from, to net.Conn, wg *sync.WaitGroup) {
+	defer wg.Done()
+	select {
+	case <-p.done:
+		return
+	default:
+		if _, err := io.Copy(to, from); err != nil {
+			p.log.WithField("err", err).Errorln("Error from copy")
+			p.Stop()
+			return
+		}
+	}
+}


### PR DESCRIPTION
# Port forward

- ./mystack port-forward binds local ports to the cluster services
- The chosen ports are default
- To choose the ports to bind, use ./mystack port-forward -i
- It starts threads to listen each service and waits them in the main thread using a WaitGroup